### PR TITLE
Add support for Python context managers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ spinner.start()
 spinner.stop()
 ```
 
+Alternatively, you can use halo with Python's `with` statement:
+
+```py
+from halo import Halo
+
+with Halo({'text': 'Loading', 'spinner': 'dots'}):
+    # Run time consuming work here
+```
+
 ## API
 
 ### `Halo([text|spinner|color|interval|stream|enabled])`

--- a/halo/__init__.py
+++ b/halo/__init__.py
@@ -2,4 +2,8 @@
 __author__ = 'Manraj Singh'
 __email__ = 'manrajsinghgrover@gmail.com'
 
+import logging
+
 from .halo import Halo
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/halo/halo.py
+++ b/halo/halo.py
@@ -6,18 +6,13 @@ from __future__ import unicode_literals, absolute_import, print_function
 
 import sys
 import threading
-import cursor
 import time
-import logging
 
+import cursor
 from spinners.spinners import Spinners
 from log_symbols.symbols import LogSymbols
-from halo._utils import is_supported, colored_frame, is_text_type, decode_utf_8_text
 
-logging.basicConfig(
-    level=logging.DEBUG,
-    format="%(asctime)s:%(levelname)s:%(message)s"
-)
+from halo._utils import is_supported, colored_frame, is_text_type, decode_utf_8_text
 
 
 class Halo(object):

--- a/halo/halo.py
+++ b/halo/halo.py
@@ -64,6 +64,18 @@ class Halo(object):
         self._spinner_id = None
         self._enabled = enabled # Need to check for stream
 
+    def __enter__(self):
+        """Starts the spinner on a separate thread. For use in context managers.
+
+        Returns
+        -------
+        self
+        """
+        return self.start()
+
+    def __exit__(self, type, value, traceback):
+        self.stop()
+
     @property
     def spinner(self):
         """Getter for spinner property.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-log_symbols==0.0.9
-spinners==0.0.17
+log_symbols==0.0.11
+spinners==0.0.19
 cursor==1.1.0
 termcolor==1.1.0
 colorama==0.3.9

--- a/tests/test_halo.py
+++ b/tests/test_halo.py
@@ -81,7 +81,7 @@ class TestHalo(unittest.TestCase):
     def test_context_manager(self):
         """Test the basic of basic spinners used through the with statement.
         """
-        with Halo({'text': 'foo', 'spinner': 'dots', 'stream': self._stream}):
+        with Halo(text='foo', spinner='dots', stream=self._stream):
             time.sleep(1)
         output = self._get_test_output()
 

--- a/tests/test_halo.py
+++ b/tests/test_halo.py
@@ -78,6 +78,18 @@ class TestHalo(unittest.TestCase):
         self.assertEqual(output[1], '{0} foo'.format(frames[1]))
         self.assertEqual(output[2], '{0} foo'.format(frames[2]))
 
+    def test_context_manager(self):
+        """Test the basic of basic spinners used through the with statement.
+        """
+        with Halo({'text': 'foo', 'spinner': 'dots', 'stream': self._stream}):
+            time.sleep(1)
+        output = self._get_test_output()
+
+        self.assertEqual(output[0], '{0} foo'.format(frames[0]))
+        self.assertEqual(output[1], '{0} foo'.format(frames[1]))
+        self.assertEqual(output[2], '{0} foo'.format(frames[2]))
+
+
     def test_initial_title_spinner(self):
         """Test Halo with initial title.
         """


### PR DESCRIPTION
I added two methods to the `Halo` class: `__enter__()` and `__exit__()`. These allows spinners to be used through Python's `with` statement like so:

```python
from halo import Halo

with Halo({'text': 'Loading', 'spinner': 'dots'}):
    # Run time consuming work here
```

---

As an aside, the way that keyword parameters are passed to the Halo class is non-Pythonic. You should just use normal kwargs with default values.