### PR TITLE
Keyword arguments to initialize Halo instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ pip install halo
 ```py
 from halo import Halo
 
-spinner = Halo({'text': 'Loading', 'spinner': 'dots'})
+spinner = Halo(text='Loading', spinner='dots')
 spinner.start()
 
 # Run time consuming work here
@@ -32,12 +32,7 @@ spinner.stop()
 
 ## API
 
-### `Halo([options|text])`
-
-If a string is given, it will be treated as text for spinner.
-
-#### `options`
-A dictionary defining various available settings.
+### `Halo([text|spinner|color|interval|stream|enabled])`
 
 ##### `text`
 *Type*: `str`

--- a/examples/custom_spins.py
+++ b/examples/custom_spins.py
@@ -9,13 +9,13 @@ os.sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from halo import Halo
 
-spinner = Halo({
-    'text': 'Custom Spins',
-    'spinner': {
+spinner = Halo(
+    text='Custom Spins',
+    spinner={
         'interval': 100,
         'frames': ['-', '+', '*', '+', '-']
     }
-})
+)
 
 try:
     spinner.start()

--- a/examples/doge_spin.py
+++ b/examples/doge_spin.py
@@ -9,7 +9,7 @@ os.sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from halo import Halo
 
-spinner = Halo({'text': 'Such Spins', 'spinner': 'dots'})
+spinner = Halo(text='Such Spins', spinner='dots')
 
 try:
     spinner.start()
@@ -18,7 +18,7 @@ try:
     spinner.color = 'magenta'
     time.sleep(2)
     spinner.text = 'Very emojis'
-    spinner.spinner = {'spinner': 'hearts'}
+    spinner.spinner = 'hearts'
     time.sleep(2)
     spinner.stop_and_persist({'symbol': '🦄 '.encode('utf-8'), 'text': 'Wow!'})
 except (KeyboardInterrupt, SystemExit):

--- a/examples/persist_spin.py
+++ b/examples/persist_spin.py
@@ -13,7 +13,7 @@ success_message = 'Loading success'
 failed_message = 'Loading failed'
 unicorn_message = 'Loading unicorn'
 
-spinner = Halo({'text': success_message, 'spinner': 'dots'})
+spinner = Halo(text=success_message, spinner='dots')
 
 try:
     spinner.start()

--- a/halo/halo.py
+++ b/halo/halo.py
@@ -23,7 +23,7 @@ logging.basicConfig(
 class Halo(object):
 
     """Halo library.
-    
+
     Attributes
     ----------
     CLEAR_LINE : str
@@ -32,45 +32,47 @@ class Halo(object):
 
     CLEAR_LINE = '\033[K'
 
-    def __init__(self, options={}):
+    def __init__(self, text='', color='cyan', spinner=None, interval=-1, enabled=True, stream=None):
         """Constructs the Halo object.
-        
+
         Parameters
         ----------
-        options : dict, optional
-            Options to be used for constructing the object.
+        text : str, optional
+            Text to display.
+        color : str, optional
+            Color of the text to display.
+        spinner : str|dict, optional
+            Spinner dict|str.
+        interval : integer, optional
+            Interval between each frame of the spinner.
+        enabled : boolean, optional
+            Spinner enabled or not.
+        stream : io, optional
+            Output.
         """
-        if is_text_type(options):
-            text = options
-            options = {}
-            options['text'] = text
 
-        self._spinner = self._get_spinner(options)
+        self._spinner = self._get_spinner(spinner)
 
-        self._options = {
-            'interval': self._spinner['interval'],
-            'text': '',
-            'color': 'cyan',
-            'enabled': True,
-            'stream': sys.stdout
-        }
+        if interval == -1:
+            self._interval = self._spinner['interval']
 
-        self._options.update(options)
+        self._text = text
+        self._color = color
 
-        self._interval = self._options['interval']
-        self._text = self._options['text']
-        self._color = self._options['color']
-        self._stream = self._options['stream']
+        if not stream:
+            stream = sys.stdout
+
+        self._stream = stream
         self._frame_index = 0
         self._spinner_thread = None
         self._stop_spinner = None
         self._spinner_id = None
-        self._enabled = self._options['enabled'] # Need to check for stream
+        self._enabled = enabled # Need to check for stream
 
     @property
     def spinner(self):
         """Getter for spinner property.
-        
+
         Returns
         -------
         dict
@@ -79,26 +81,22 @@ class Halo(object):
         return self._spinner
 
     @spinner.setter
-    def spinner(self, options):
+    def spinner(self, spinner=None):
         """Setter for spinner property.
-        
+
         Parameters
         ----------
-        options : dict, str
+        spinner : dict, str
             Defines the spinner value with frame and interval
         """
-        if is_text_type(options):
-            spinner = options
-            options = {}
-            options['spinner'] = spinner
 
-        self._spinner = self._get_spinner(options)
+        self._spinner = self._get_spinner(spinner)
         self._frame_index = 0
 
     @property
     def text(self):
         """Getter for text property.
-        
+
         Returns
         -------
         str
@@ -109,7 +107,7 @@ class Halo(object):
     @text.setter
     def text(self, text):
         """Setter for text property.
-        
+
         Parameters
         ----------
         text : str
@@ -120,7 +118,7 @@ class Halo(object):
     @property
     def color(self):
         """Getter for color property.
-        
+
         Returns
         -------
         str
@@ -131,7 +129,7 @@ class Halo(object):
     @color.setter
     def color(self, color):
         """Setter for color property.
-        
+
         Parameters
         ----------
         color : str
@@ -142,7 +140,7 @@ class Halo(object):
     @property
     def spinner_id(self):
         """Getter for spinner id
-        
+
         Returns
         -------
         str
@@ -150,15 +148,15 @@ class Halo(object):
         """
         return self._spinner_id
 
-    def _get_spinner(self, options):
+    def _get_spinner(self, spinner):
         """Extracts spinner value from options and returns value
         containing spinner frames and interval, defaults to 'dots' spinner.
-        
+
         Parameters
         ----------
-        options : dict, str
+        spinner : dict, str
             Contains spinner value or type of spinner to be used
-        
+
         Returns
         -------
         dict
@@ -167,13 +165,11 @@ class Halo(object):
         default_spinner = Spinners['dots'].value
 
         if is_supported():
-            if type(options) == dict and 'spinner' in options:
-                spinner = options['spinner']
-
+            if spinner:
                 if type(spinner) == dict:
                     return spinner
                 elif is_text_type(spinner) and spinner in Spinners.__members__:
-                        return Spinners[spinner].value
+                    return Spinners[spinner].value
         else:
             return Spinners['line'].value
 
@@ -182,7 +178,7 @@ class Halo(object):
     def clear(self):
         """Clears the line and returns cursor to the start.
         of line
-        
+
         Returns
         -------
         self
@@ -205,7 +201,7 @@ class Halo(object):
 
     def render(self):
         """Runs the render until thread flag is set.
-        
+
         Returns
         -------
         self
@@ -218,7 +214,7 @@ class Halo(object):
 
     def frame(self):
         """Builds and returns the frame to be rendered
-        
+
         Returns
         -------
         self
@@ -236,12 +232,12 @@ class Halo(object):
 
     def start(self, text=None):
         """Starts the spinner on a separate thread.
-        
+
         Parameters
         ----------
         text : None, optional
             Text to be used alongside spinner
-        
+
         Returns
         -------
         self
@@ -266,7 +262,7 @@ class Halo(object):
 
     def stop(self):
         """Stops the spinner and clears the line.
-        
+
         Returns
         -------
         self
@@ -289,12 +285,12 @@ class Halo(object):
 
     def succeed(self, text=None):
         """Shows and persists success symbol and text and exits.
-        
+
         Parameters
         ----------
         text : None, optional
             Text to be shown alongside success symbol.
-        
+
         Returns
         -------
         self
@@ -303,12 +299,12 @@ class Halo(object):
 
     def fail(self, text=None):
         """Shows and persists fail symbol and text and exits.
-        
+
         Parameters
         ----------
         text : None, optional
             Text to be shown alongside fail symbol.
-        
+
         Returns
         -------
         self
@@ -317,12 +313,12 @@ class Halo(object):
 
     def warn(self, text=None):
         """Shows and persists warn symbol and text and exits.
-        
+
         Parameters
         ----------
         text : None, optional
             Text to be shown alongside warn symbol.
-        
+
         Returns
         -------
         self
@@ -331,12 +327,12 @@ class Halo(object):
 
     def info(self, text=None):
         """Shows and persists info symbol and text and exits.
-        
+
         Parameters
         ----------
         text : None, optional
             Text to be shown alongside info symbol.
-        
+
         Returns
         -------
         self
@@ -345,16 +341,16 @@ class Halo(object):
 
     def stop_and_persist(self, options={}):
         """Stops the spinner and persists the final frame to be shown.
-        
+
         Parameters
         ----------
         options : dict, optional
             Contains frame and interval for final frame
-        
+
         Returns
         -------
         self
-        
+
         Raises
         ------
         TypeError

--- a/tests/test_halo.py
+++ b/tests/test_halo.py
@@ -211,15 +211,6 @@ class TestHalo(unittest.TestCase):
         else:
             self.assertEqual(spinner.spinner, default_spinner)
 
-        spinner.spinner = {
-            "interval": 100,
-            "frames": ["◉", "◎"]
-        }
-        if is_supported():
-            self.assertEqual(spinner.spinner, Spinners['toggle9'].value)
-        else:
-            self.assertEqual(spinner.spinner, default_spinner)
-
         spinner.spinner = 'foo_bar'
         self.assertEqual(spinner.spinner, default_spinner)
 

--- a/tests/test_halo.py
+++ b/tests/test_halo.py
@@ -47,7 +47,7 @@ class TestHalo(unittest.TestCase):
 
     def _get_test_output(self):
         """Clean the output from stream and return it in list form.
-        
+
         Returns
         -------
         list
@@ -67,7 +67,8 @@ class TestHalo(unittest.TestCase):
     def test_basic_spinner(self):
         """Test the basic of basic spinners.
         """
-        spinner = Halo({'text': 'foo', 'spinner': 'dots', 'stream': self._stream})
+        spinner = Halo(text='foo', spinner='dots', stream=self._stream)
+
         spinner.start()
         time.sleep(1)
         spinner.stop()
@@ -98,13 +99,13 @@ class TestHalo(unittest.TestCase):
     def test_id_not_created_before_start(self):
         """Test Spinner ID not created before start.
         """
-        spinner = Halo({'stream': self._stream})
+        spinner = Halo(stream=self._stream)
         self.assertEqual(spinner.spinner_id, None)
 
     def test_ignore_multiple_start_calls(self):
         """Test ignoring of multiple start calls.
         """
-        spinner = Halo({'stream': self._stream})
+        spinner = Halo(stream=self._stream)
         spinner.start()
         spinner_id = spinner.spinner_id
         spinner.start()
@@ -114,7 +115,7 @@ class TestHalo(unittest.TestCase):
     def test_chaining_start(self):
         """Test chaining start with constructor
         """
-        spinner = Halo({'stream': self._stream}).start()
+        spinner = Halo(stream=self._stream).start()
         spinner_id = spinner.spinner_id
         self.assertIsNotNone(spinner_id)
         spinner.stop()
@@ -122,7 +123,7 @@ class TestHalo(unittest.TestCase):
     def test_succeed(self):
         """Test succeed method
         """
-        spinner = Halo({'stream': self._stream})
+        spinner = Halo(stream=self._stream)
         spinner.start('foo')
         spinner.succeed('foo')
 
@@ -135,7 +136,7 @@ class TestHalo(unittest.TestCase):
     def test_succeed_with_new_text(self):
         """Test succeed method with new text
         """
-        spinner = Halo({'stream': self._stream})
+        spinner = Halo(stream=self._stream)
         spinner.start('foo')
         spinner.succeed('bar')
 
@@ -148,7 +149,7 @@ class TestHalo(unittest.TestCase):
     def test_info(self):
         """Test info method
         """
-        spinner = Halo({'stream': self._stream})
+        spinner = Halo(stream=self._stream)
         spinner.start('foo')
         spinner.info()
 
@@ -161,7 +162,7 @@ class TestHalo(unittest.TestCase):
     def test_fail(self):
         """Test fail method
         """
-        spinner = Halo({'stream': self._stream})
+        spinner = Halo(stream=self._stream)
         spinner.start('foo')
         spinner.fail()
 
@@ -174,7 +175,7 @@ class TestHalo(unittest.TestCase):
     def test_warning(self):
         """Test warn method
         """
-        spinner = Halo({'stream': self._stream})
+        spinner = Halo(stream=self._stream)
         spinner.start('foo')
         spinner.warn('Warning!')
 
@@ -204,13 +205,22 @@ class TestHalo(unittest.TestCase):
         else:
             self.assertEqual(spinner.spinner, default_spinner)
 
-        spinner.spinner = {'spinner': 'dots11'}
+        spinner.spinner = 'dots11'
         if is_supported():
             self.assertEqual(spinner.spinner, Spinners['dots11'].value)
         else:
             self.assertEqual(spinner.spinner, default_spinner)
 
-        spinner.spinner = {'spinner': 'foo_bar'}
+        spinner.spinner = {
+            "interval": 100,
+            "frames": ["◉", "◎"]
+        }
+        if is_supported():
+            self.assertEqual(spinner.spinner, Spinners['toggle9'].value)
+        else:
+            self.assertEqual(spinner.spinner, default_spinner)
+
+        spinner.spinner = 'foo_bar'
         self.assertEqual(spinner.spinner, default_spinner)
 
         # Color is None
@@ -232,7 +242,7 @@ class TestHalo(unittest.TestCase):
         """
         stdout_ = sys.stdout
         sys.stdout = self._stream
-        spinner = Halo({'text': 'foo', 'enabled': False})
+        spinner = Halo(text="foo", enabled=False)
         spinner.start()
         time.sleep(1)
         spinner.clear()


### PR DESCRIPTION
Replaced the dict initialization of `Halo` objects with a keyword initialization.

``` python 
Halo({'text': 'Loading', 'spinner': 'dots'})
```
to
``` python 
Halo(text='Loading', spinner='dots')
```

I also made the necessary modifications on the tests, readme and examples.
(My text editor removed a lot of whitespaces, sorry about that.)