### PR TITLE
Fixes #8: Strips text before rendering

### DIFF
--- a/halo/halo.py
+++ b/halo/halo.py
@@ -128,7 +128,7 @@ class Halo(object):
         text : str
             Defines the text value for spinner
         """
-        self._text = text
+        self._text = text.strip()
 
     @property
     def color(self):
@@ -248,7 +248,7 @@ class Halo(object):
         self
         """
         if text is not None:
-            self._text = text
+            self._text = text.strip()
 
         if not self._enabled or self._spinner_id is not None:
             return self
@@ -361,6 +361,8 @@ class Halo(object):
             text = decode_utf_8_text(options['text'])
         else:
             text = self._text
+
+        text = text.strip()
 
         self.stop()
 

--- a/halo/halo.py
+++ b/halo/halo.py
@@ -50,7 +50,7 @@ class Halo(object):
         if interval == -1:
             self._interval = self._spinner['interval']
 
-        self._text = text
+        self._text = text.strip()
         self._color = color
 
         if not stream:

--- a/halo/halo.py
+++ b/halo/halo.py
@@ -58,7 +58,7 @@ class Halo(object):
         self._options.update(options)
 
         self._interval = self._options['interval']
-        self._text = self._options['text']
+        self._text = self._options['text'].strip()
         self._color = self._options['color']
         self._stream = self._options['stream']
         self._frame_index = 0

--- a/tests/test_halo.py
+++ b/tests/test_halo.py
@@ -78,6 +78,24 @@ class TestHalo(unittest.TestCase):
         self.assertEqual(output[1], '{0} foo'.format(frames[1]))
         self.assertEqual(output[2], '{0} foo'.format(frames[2]))
 
+    def test_text_stripping(self):
+        """Test the text being stripped before output.
+        """
+        spinner = Halo(text='foo\n', spinner='dots', stream=self._stream)
+
+        spinner.start()
+        time.sleep(1)
+        spinner.succeed('foo\n')
+        output = self._get_test_output()
+
+        self.assertEqual(output[0], '{0} foo'.format(frames[0]))
+        self.assertEqual(output[1], '{0} foo'.format(frames[1]))
+        self.assertEqual(output[2], '{0} foo'.format(frames[2]))
+
+        pattern = re.compile(r'(✔|v) foo', re.UNICODE)
+
+        self.assertRegexpMatches(output[-1], pattern)
+
     def test_context_manager(self):
         """Test the basic of basic spinners used through the with statement.
         """


### PR DESCRIPTION
Strip the text in the constructor so that if there is a newline in the text, then it won't display each step of the progress bar on a new line.