### PR TITLE
Requirements: Dependencies updated

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-log_symbols==0.0.9
-spinners==0.0.17
+log_symbols==0.0.11
+spinners==0.0.19
 cursor==1.1.0
 termcolor==1.1.0
 colorama==0.3.9


### PR DESCRIPTION
Following dependencies have been bumped:

1. `log_symbols`: `0.0.9` to `0.0.11`
2. `spinners `: `0.0.17` to `0.0.19`