### PR TITLE
BUG FIX: Fix xrange to range in example for supporting python3

### DIFF
--- a/examples/loader_spin.py
+++ b/examples/loader_spin.py
@@ -14,7 +14,7 @@ spinner = Halo(text='Downloading dataset.zip', spinner='dots')
 
 try:
     spinner.start()
-    for i in xrange(100):
+    for i in range(100):
         spinner.text = '{0}% Downloaded dataset.zip'.format(i)
         time.sleep(random.random())
     spinner.succeed('Downloaded dataset.zip')


### PR DESCRIPTION
## Description of new feature, or changes
Fix [`loader_spin.py` in examples](https://github.com/ManrajGrover/halo/blob/master/examples/loader_spin.py). In the code, `xrange` is used, but it's not compatible with python3. Although `range` method copies memory on python2, it is not a big deal.


## Checklist

- [x] Your branch is up-to-date with the base branch
- [ ] You've included at least one test if this is a new feature
- [x] All tests are passing

## Related Issues and Discussions
I skipped because it was too small to open issue.
