### PR TITLE
#35: Improve keyboard interrupt handling in iPython

### DIFF
--- a/halo/halo.py
+++ b/halo/halo.py
@@ -66,7 +66,8 @@ class Halo(object):
         self._enabled = enabled  # Need to check for stream
 
         def handle_keyboard_interrupt(signal, frame):
-            self.fail("END")
+            """Handle KeyboardInterrupt without try-except statement"""
+            self.fail(self.text)
             raise KeyboardInterrupt
 
         signal.signal(signal.SIGINT, handle_keyboard_interrupt)

--- a/halo/halo.py
+++ b/halo/halo.py
@@ -5,6 +5,7 @@
 from __future__ import unicode_literals, absolute_import, print_function
 
 import sys
+import signal
 import threading
 import time
 import functools
@@ -63,6 +64,12 @@ class Halo(object):
         self._stop_spinner = None
         self._spinner_id = None
         self._enabled = enabled  # Need to check for stream
+
+        def handle_keyboard_interrupt(signal, frame):
+            self.fail("END")
+            raise KeyboardInterrupt
+
+        signal.signal(signal.SIGINT, handle_keyboard_interrupt)
 
     def __enter__(self):
         """Starts the spinner on a separate thread. For use in context managers.

--- a/tests/test_halo.py
+++ b/tests/test_halo.py
@@ -341,25 +341,6 @@ class TestHalo(unittest.TestCase):
             spinner.start()
             spinner.stop_and_persist('not dict')
 
-    def test_spinner_keyboard_interrupt(self):
-        """Test Halo with keyboard interrupt.
-        """
-        spinner = Halo(text='foo', spinner='dots', stream=self._stream)
-
-        with self.assertRaises(KeyboardInterrupt):
-            spinner.start()
-            time.sleep(1)
-            pid = os.getpid()
-            os.kill(pid, signal.SIGINT)
-
-        output = self._get_test_output()
-        self.assertEqual(output[0], '{0} foo'.format(frames[0]))
-        self.assertEqual(output[1], '{0} foo'.format(frames[1]))
-        self.assertEqual(output[2], '{0} foo'.format(frames[2]))
-
-        pattern = re.compile(r'(✖|×) foo', re.UNICODE)
-        self.assertRegexpMatches(output[-1], pattern)
-
     def tearDown(self):
         """Clean up things after every test.
         """

--- a/tests/test_halo.py
+++ b/tests/test_halo.py
@@ -5,6 +5,7 @@ import re
 import unittest
 import time
 import sys
+import signal
 import io
 import logging
 import os
@@ -339,6 +340,25 @@ class TestHalo(unittest.TestCase):
             spinner = Halo()
             spinner.start()
             spinner.stop_and_persist('not dict')
+
+    def test_spinner_keyboard_interrupt(self):
+        """Test Halo with keyboard interrupt.
+        """
+        spinner = Halo(text='foo', spinner='dots', stream=self._stream)
+
+        with self.assertRaises(KeyboardInterrupt):
+            spinner.start()
+            time.sleep(1)
+            pid = os.getpid()
+            os.kill(pid, signal.SIGINT)
+
+        output = self._get_test_output()
+        self.assertEqual(output[0], '{0} foo'.format(frames[0]))
+        self.assertEqual(output[1], '{0} foo'.format(frames[1]))
+        self.assertEqual(output[2], '{0} foo'.format(frames[2]))
+
+        pattern = re.compile(r'(✖|×) foo', re.UNICODE)
+        self.assertRegexpMatches(output[-1], pattern)
 
     def tearDown(self):
         """Clean up things after every test.


### PR DESCRIPTION
## Description of changes
This PR resolve the issue #35. In an iPython, if a user rises `KeyboardInterrupt` without handling error statement, the cell is broken and spinner remains.

## Checklist

- [x] Your branch is up-to-date with the base branch
- [x] You've included at least one test if this is a new feature
- [x] All tests are passing

## Related Issues and Discussions
Fixed #35 refer #32

## People to notify
@ManrajGrover 
