### PR TITLE
Fixes #42: No text should be shown on KeyboardInterrupt

### DIFF
--- a/halo/halo.py
+++ b/halo/halo.py
@@ -67,7 +67,7 @@ class Halo(object):
 
         def handle_keyboard_interrupt(signal, frame):
             """Handle KeyboardInterrupt without try-except statement"""
-            self.fail(self.text)
+            self.stop()
             raise KeyboardInterrupt
 
         signal.signal(signal.SIGINT, handle_keyboard_interrupt)


### PR DESCRIPTION
<!--  Use the following format for your Pull Request title:

    BUG FIX
    {Issue ID|BUG FIX}: {Description of change}

    OTHERS
    {Whatever}: {Description of change} -->

## Description of new feature, or changes
Currently, when KeyboardInterrupt is raised, handler persists current text and shows failed. We should allow user to choose the preferable output and not handle it ourselves.

## Checklist

- [x] Your branch is up-to-date with the base branch
- [ ] You've included at least one test if this is a new feature
- [x] All tests are passing

## Related Issues and Discussions
Fixes #42

## People to notify
@JungWinter 
