### PR TITLE
Fixes #56: Add placement parameter that allows spinner on right side of text

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ long_running_function()
 
 ## API
 
-### `Halo([text|spinner|color|interval|stream|enabled])`
+### `Halo([text|spinner|animation|placement|color|interval|stream|enabled])`
 
 ##### `text`
 *Type*: `str`
@@ -80,6 +80,12 @@ Defaults to `dots` spinner. For Windows users, it defaults to `line` spinner.
 *Values*: `bounce`, `marquee`
 
 Animation to apply to the text if it's too large and doesn't fit in the terminal. If no animation is defined, the text will be ellipsed.
+
+##### `placement`
+*Type*: `str`
+*Values*: `left`, `right`
+
+Which side of the text the spinner should be displayed. Defaults to `left`
 
 ##### `color`
 *Type*: `str`

--- a/halo/halo.py
+++ b/halo/halo.py
@@ -26,7 +26,7 @@ class Halo(object):
     """
 
     CLEAR_LINE = '\033[K'
-    SPINNER_PLACEMENTS = ['left', 'right']
+    SPINNER_PLACEMENTS = ('left', 'right',)
 
     def __init__(self, text='', color='cyan', spinner=None, animation=None, placement='left', interval=-1, enabled=True, stream=None):
         """Constructs the Halo object.

--- a/halo/halo.py
+++ b/halo/halo.py
@@ -26,8 +26,9 @@ class Halo(object):
     """
 
     CLEAR_LINE = '\033[K'
+    SPINNER_PLACEMENTS = ['left', 'right']
 
-    def __init__(self, text='', color='cyan', spinner=None, animation=None, interval=-1, enabled=True, stream=None):
+    def __init__(self, text='', color='cyan', spinner=None, animation=None, placement='left', interval=-1, enabled=True, stream=None):
         """Constructs the Halo object.
         Parameters
         ----------
@@ -41,6 +42,9 @@ class Halo(object):
         animation: str, optional
             Animation to apply if text is too large. Can be one of `bounce`, `marquee`.
             Defaults to ellipses.
+        placement: str, optional
+            Side of the text to place the spinner on. Can be `left` or `right`.
+            Defaults to `left`.
         interval : integer, optional
             Interval between each frame of the spinner in milliseconds.
         enabled : boolean, optional
@@ -63,6 +67,7 @@ class Halo(object):
         if not stream:
             stream = sys.stdout
 
+        self.placement = placement
         self._stream = stream
         self._frame_index = 0
         self._text_index = 0
@@ -165,6 +170,28 @@ class Halo(object):
             Defines the color value for spinner
         """
         self._color = color
+
+    @property
+    def placement(self):
+        """Getter for placement property.
+        Returns
+        -------
+        str
+            spinner placement
+        """
+        return self._placement
+
+    @placement.setter
+    def placement(self, placement):
+        """Setter for placement property.
+        Parameters
+        ----------
+        placement: str
+            Defines the placement of the spinner
+        """
+        if placement not in self.SPINNER_PLACEMENTS:
+            raise ValueError("unknown spinner placement '{0}', available are {1}".format(placement, self.SPINNER_PLACEMENTS))
+        self._placement = placement
 
     @property
     def spinner_id(self):
@@ -295,7 +322,12 @@ class Halo(object):
         self._frame_index += 1
         self._frame_index = self._frame_index % len(frames)
 
-        return frame + ' ' + self.text_frame()
+        text_frame = self.text_frame()
+        return u'{0} {1}'.format(*[
+            (text_frame, frame)
+            if self._placement == 'right' else
+            (frame, text_frame)
+        ][0])
 
     def text_frame(self):
         """Builds and returns the text frame to be rendered
@@ -440,7 +472,11 @@ class Halo(object):
 
         self.stop()
 
-        output = u'{0} {1}\n'.format(symbol, text)
+        output = u'{0} {1}\n'.format(*[
+            (text, symbol)
+            if self._placement == 'right' else
+            (symbol, text)
+        ][0])
         self._stream.write(output)
 
         return self

--- a/halo/halo_notebook.py
+++ b/halo/halo_notebook.py
@@ -9,9 +9,9 @@ from IPython.display import display
 
 
 class HaloNotebook(Halo):
-    def __init__(self, text='', color='cyan', spinner=None, animation=None, interval=-1, enabled=True, stream=None):
+    def __init__(self, text='', color='cyan', spinner=None, placement='left', animation=None, interval=-1, enabled=True, stream=None):
 
-        super(HaloNotebook, self).__init__(text=text, color=color, spinner=spinner, animation=animation,
+        super(HaloNotebook, self).__init__(text=text, color=color, spinner=spinner, placement=placement, animation=animation,
                                            interval=interval, enabled=enabled,
                                            stream=stream)
         self.output = self._make_output_widget()
@@ -88,7 +88,11 @@ class HaloNotebook(Halo):
 
         self.stop()
 
-        output = '\r{0} {1}\n'.format(symbol, text)
+        output = '\r{0} {1}\n'.format(*[
+            (text, symbol)
+            if self._placement == 'right' else
+            (symbol, text)
+        ][0])
 
         with self.output:
             self.output.outputs = self._output(output)

--- a/tests/test_halo.py
+++ b/tests/test_halo.py
@@ -351,6 +351,47 @@ class TestHalo(unittest.TestCase):
         spinner = Halo(spinner={'interval': 321, 'frames': ['+', '-']})
         self.assertEqual(spinner._interval, 321)
 
+    def test_invalid_placement(self):
+        """Test invalid placement of spinner.
+        """
+
+        with self.assertRaises(ValueError):
+            Halo(placement='')
+            Halo(placement='foo')
+            Halo(placement=None)
+
+        spinner = Halo(placement='left')
+        with self.assertRaises(ValueError):
+            spinner.placement = ''
+            spinner.placement = 'foo'
+            spinner.placement = None
+
+    def test_default_placement(self):
+        """Test default placement of spinner.
+        """
+
+        spinner = Halo()
+        self.assertEqual(spinner.placement, 'left')
+
+    def test_right_placement(self):
+        """Test right placement of spinner.
+        """
+        spinner = Halo(text='foo', placement='right', stream=self._stream)
+        spinner.start()
+        output = self._get_test_output()
+
+        (text, _) = output[-1].split(' ')
+        self.assertEqual(text, 'foo')
+
+        spinner.succeed()
+        output = self._get_test_output()
+        (text, symbol) = output[-1].split(' ')
+        pattern = re.compile(r"(✔|v)", re.UNICODE)
+
+        self.assertEqual(text, 'foo')
+        self.assertRegexpMatches(symbol, pattern)
+        spinner.stop()
+
     def tearDown(self):
         """Clean up things after every test.
         """

--- a/tests/test_halo.py
+++ b/tests/test_halo.py
@@ -378,8 +378,9 @@ class TestHalo(unittest.TestCase):
         """
         spinner = Halo(text='foo', placement='right', stream=self._stream)
         spinner.start()
-        output = self._get_test_output()
+        time.sleep(1)
 
+        output = self._get_test_output()
         (text, _) = output[-1].split(' ')
         self.assertEqual(text, 'foo')
 

--- a/tests/test_halo_notebook.py
+++ b/tests/test_halo_notebook.py
@@ -361,8 +361,9 @@ class TestHaloNotebook(unittest.TestCase):
         """
         spinner = HaloNotebook(text="foo", placement="right")
         spinner.start()
-        output = self._get_test_output(spinner)
+        time.sleep(1)
 
+        output = self._get_test_output(spinner)
         (text, _) = output[-1].split(" ")
         self.assertEqual(text, "foo")
 

--- a/tests/test_halo_notebook.py
+++ b/tests/test_halo_notebook.py
@@ -334,6 +334,48 @@ class TestHaloNotebook(unittest.TestCase):
         self.assertEqual(len(output), 0)
         self.assertEqual(output, [])
 
+    def test_invalid_placement(self):
+        """Test invalid placement of spinner.
+        """
+
+        with self.assertRaises(ValueError):
+            HaloNotebook(placement='')
+            HaloNotebook(placement='foo')
+            HaloNotebook(placement=None)
+
+        spinner = HaloNotebook(placement='left')
+        with self.assertRaises(ValueError):
+            spinner.placement = ''
+            spinner.placement = 'foo'
+            spinner.placement = None
+
+    def test_default_placement(self):
+        """Test default placement of spinner.
+        """
+
+        spinner = HaloNotebook()
+        self.assertEqual(spinner.placement, 'left')
+
+    def test_right_placement(self):
+        """Test right placement of spinner.
+        """
+        spinner = HaloNotebook(text="foo", placement="right")
+        spinner.start()
+        output = self._get_test_output(spinner)
+
+        (text, _) = output[-1].split(" ")
+        self.assertEqual(text, "foo")
+
+        spinner.succeed()
+        output = self._get_test_output(spinner)
+        print(output)
+        (text, symbol) = output[-1].split(" ")
+        pattern = re.compile(r"(✔|v)", re.UNICODE)
+
+        self.assertEqual(text, "foo")
+        self.assertRegexpMatches(symbol, pattern)
+        spinner.stop()
+
     def tearDown(self):
         """Clean up things after every test.
         """

--- a/tests/test_halo_notebook.py
+++ b/tests/test_halo_notebook.py
@@ -369,7 +369,6 @@ class TestHaloNotebook(unittest.TestCase):
 
         spinner.succeed()
         output = self._get_test_output(spinner)
-        print(output)
         (text, symbol) = output[-1].split(" ")
         pattern = re.compile(r"(✔|v)", re.UNICODE)
 


### PR DESCRIPTION
## Description of new feature, or changes
Adds the `placement` parameter which allows placement of the spinner on either the right or left side of the text using the values `right` and `left`.
Defaults to `left`

The only real logic changes are checking if the placement value is set to `right` and then switching the text and spinner frames in a `str.fomat` call.

```python
# simple usage
with Halo(text='Spinning...', placement='right') as spinner:
    time.sleep(1)

Spinning... ⠧


# invalid placements raise ValueError
with Halo(text='Spinning...', placement='invalid') as spinner:
    time.sleep(1)

Traceback (most recent call last):
  File "main.py", line 4, in <module>
    with Halo('foobar', placement='invalid') as sp:
  File "C:\Users\r\Documents\GitHub\halo\halo\halo.py", line 70, in __init__
    self.placement = placement
  File "C:\Users\r\Documents\GitHub\halo\halo\halo.py", line 193, in placement
    raise ValueError("unknown spinner placement '{0}', available are {1}".format(placement, self.SPINNER_PLACEMENTS))
ValueError: unknown spinner placement 'invalid', available are ('left', 'right')
```

Opening additional PR (previous #52) because original repo was removed.

## Checklist

- [x] Your branch is up-to-date with the base branch
- [x] You've included at least one test if this is a new feature
- [x] All tests are passing

## Related Issues and Discussions
Fixes: #56 
Closes: #52 

## People to notify
@ManrajGrover