### PR TITLE
Fix IPython-less mode of get_environment

### DIFF
--- a/halo/_utils.py
+++ b/halo/_utils.py
@@ -38,7 +38,10 @@ def get_environment():
     """
     try:
         from IPython import get_ipython
-
+    except ImportError:
+        return 'terminal'
+    
+    try:
         shell = get_ipython().__class__.__name__
 
         if shell == 'ZMQInteractiveShell': # Jupyter notebook or qtconsole


### PR DESCRIPTION
Former fix was incomplete, so in environments without IPython at all, the `ImportError` being raised wasn't caught properly.

This PR is supposed to fix it.