### PR TITLE
Use get_terminal_size directly from shutil on newer Python version.

### DIFF
--- a/halo/_utils.py
+++ b/halo/_utils.py
@@ -5,10 +5,10 @@ import codecs
 import platform
 import six
 from sys import version_info
-if version_info.major >= 3 and version_info.minor >= 3:
-    from shutil import get_terminal_size
-else:
+if version_info.major == 2 or (version_info.major == 3 and version_info.minor < 3):
     from backports.shutil_get_terminal_size import get_terminal_size
+else:
+    from shutil import get_terminal_size
 
 from colorama import init
 from termcolor import colored

--- a/halo/_utils.py
+++ b/halo/_utils.py
@@ -4,11 +4,10 @@
 import codecs
 import platform
 import six
-from sys import version_info
-if version_info.major == 2 or (version_info.major == 3 and version_info.minor < 3):
-    from backports.shutil_get_terminal_size import get_terminal_size
-else:
+try:
     from shutil import get_terminal_size
+except:
+    from backports.shutil_get_terminal_size import get_terminal_size
 
 from colorama import init
 from termcolor import colored

--- a/halo/_utils.py
+++ b/halo/_utils.py
@@ -5,7 +5,7 @@ import codecs
 import platform
 import six
 from sys import version_info
-if version_info >= (3, 3):
+if version_info.major >= 3 and version_info.minor >= 3:
     from shutil import get_terminal_size
 else:
     from backports.shutil_get_terminal_size import get_terminal_size

--- a/halo/_utils.py
+++ b/halo/_utils.py
@@ -4,7 +4,11 @@
 import codecs
 import platform
 import six
-from backports.shutil_get_terminal_size import get_terminal_size
+from sys import version_info
+if version_info >= (3, 3):
+    from shutil import get_terminal_size
+else:
+    from backports.shutil_get_terminal_size import get_terminal_size
 
 from colorama import init
 from termcolor import colored

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-backports.shutil_get_terminal_size==1.0.0
+backports.shutil_get_terminal_size==1.0.0;python_version < '3.3'
 log_symbols==0.0.11
 spinners==0.0.23
 cursor==1.2.0


### PR DESCRIPTION
<!--  Use the following format for your Pull Request title:

    BUG FIX
    {Issue ID|BUG FIX}: {Description of change}

    OTHERS
    {Whatever}: {Description of change} -->

## Description of new feature, or changes
I'm currently creating a Arch Linux AUR package for halo. Arch Linux ships with Python 3.7. Since Python 3.3 it is possible to use `get_terminal_size` directly from the `shutils` module. So it is not necessary to use the back-ported version of `get_terminal_size` for newer versions of Python. This PR will remove the dependency of `backports.shutil_get_terminal_size` for systems with Python >= 3.3 and keep the dependency for older Python versions.

## Checklist

- [x] Your branch is up-to-date with the base branch
- [ ] You've included at least one test if this is a new feature
- [ ] All tests are passing

I did not figure out how to run the test suite. A short developer guide might be useful.

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #12" -->

## People to notify
<!-- Please @mention relevant people here: -->
