### PR TITLE
BUG FIX: Fix test_bounce_animation

### DIFF
--- a/tests/test_halo.py
+++ b/tests/test_halo.py
@@ -400,20 +400,22 @@ class TestHalo(unittest.TestCase):
         def filler_text(n_chars):
             return "_" * n_chars
 
-        text = "{}abc".format(filler_text(80))
+        terminal_width = get_terminal_columns()
+
+        text = "{}abc".format(filler_text(terminal_width))
         expected_frames_without_appended_spinner = [
-            "{}".format(filler_text(78)),
-            "{}".format(filler_text(78)),
-            "{}".format(filler_text(78)),
-            "{}a".format(filler_text(77)),
-            "{}ab".format(filler_text(76)),
-            "{}abc".format(filler_text(75)),
-            "{}abc".format(filler_text(75)),
-            "{}ab".format(filler_text(76)),
-            "{}a".format(filler_text(77)),
-            "{}".format(filler_text(78)),
-            "{}".format(filler_text(78)),
-            "{}".format(filler_text(78)),
+            "{}".format(filler_text(terminal_width - 2)),
+            "{}".format(filler_text(terminal_width - 2)),
+            "{}".format(filler_text(terminal_width - 2)),
+            "{}a".format(filler_text(terminal_width - 3)),
+            "{}ab".format(filler_text(terminal_width - 4)),
+            "{}abc".format(filler_text(terminal_width - 5)),
+            "{}abc".format(filler_text(terminal_width - 5)),
+            "{}ab".format(filler_text(terminal_width - 4)),
+            "{}a".format(filler_text(terminal_width - 3)),
+            "{}".format(filler_text(terminal_width - 2)),
+            "{}".format(filler_text(terminal_width - 2)),
+            "{}".format(filler_text(terminal_width - 2)),
         ]
         # Prepend the actual spinner
         expected_frames = [
@@ -427,8 +429,8 @@ class TestHalo(unittest.TestCase):
         spinner.stop()
         output = self._get_test_output()
 
-        zippped_expected_and_actual_frame = zip(expected_frames, output)
-        for multiple_frames in zippped_expected_and_actual_frame:
+        zipped_expected_and_actual_frame = zip(expected_frames, output)
+        for multiple_frames in zipped_expected_and_actual_frame:
             expected_frame, actual_frame = multiple_frames
             self.assertEquals(expected_frame, actual_frame)
 


### PR DESCRIPTION
## Description of new feature, or changes
When I ran my initial tox the `test_bounce_animation` test was
failing for me because it seemed to assume that my console would
be 80 characters wide, which it was not. I used your existing
`get_terminal_columns` function to remove the assumption, and now
the test should pass regardless of the width of the tester's
console.

I also fixed a typo.

## Checklist

- [x] Your branch is up-to-date with the base branch
- [x] You've included at least one test if this is a new feature
- [x] All tests are passing (I was only able to run the py36 tests)

## Related Issues and Discussions
This fixes an issue [raised](https://github.com/manrajgrover/halo/pull/78#issuecomment-428096150) in [#78](https://github.com/manrajgrover/halo/pull/78).

## People to notify
@manrajgrover @otivvormes