### PR TITLE
Fixes #31: migrate setup.py long_description to markdown README for Pypi

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,7 @@ coverage==4.4.1
 nose==1.3.7
 pylint==1.7.2
 tox==2.8.2
+twine==1.12.1
+setuptools==40.4.3
+wheel==0.32.2
+readme-renderer==23.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,3 @@ nose==1.3.7
 pylint==1.7.2
 tox==2.8.2
 twine==1.12.1
-setuptools==40.4.3
-wheel==0.32.2
-readme-renderer==23.0

--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,17 @@ def dependencies(file):
         return f.read().splitlines()
 
 
+with open("README.md") as infile:
+    long_description = infile.read()
+
 setup(
     name='halo',
     packages=find_packages(exclude=('tests', 'examples')),
     version='0.0.18',
     license='MIT',
     description='Beautiful terminal spinners in Python',
-    long_description='Beautiful terminal spinners in Python. Find the documentation here: https://github.com/ManrajGrover/halo',
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     author='Manraj Singh',
     author_email='manrajsinghgrover@gmail.com',
     url='https://github.com/manrajgrover/halo',


### PR DESCRIPTION

## Changes
Fixes #31: uses latest `wheel`, `setuptools`, and `twine` to use markdown README for long_description as described [here](https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi) 

## People to notify
@manrajgrover @PritishSehzpaul
