### PR TITLE
BUG FIX: Support pylint on Python 3

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -15,14 +15,22 @@ ignore-patterns=
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-init-hook="exec 'aW1wb3J0IHN5cywgb3MKCmlmICdWSVJUVUFMX0VOVicgbm90IGluIG9zLmVudmlyb246CiAgICBz \
-     eXMuZXhpdCgwKQoKdmVfZGlyID0gb3MuZW52aXJvblsnVklSVFVBTF9FTlYnXQp2ZV9kaXIgaW4g \
-     c3lzLnBhdGggb3Igc3lzLnBhdGguaW5zZXJ0KDAsIHZlX2RpcikKYWN0aXZhdGVfdGhpcyA9IG9z \
-     LnBhdGguam9pbihvcy5wYXRoLmpvaW4odmVfZGlyLCAnYmluJyksICdhY3RpdmF0ZV90aGlzLnB5 \
-     JykKCiMgRml4IGZvciB3aW5kb3dzCmlmIG5vdCBvcy5wYXRoLmV4aXN0cyhhY3RpdmF0ZV90aGlz \
-     KToKICAgIGFjdGl2YXRlX3RoaXMgPSBvcy5wYXRoLmpvaW4ob3MucGF0aC5qb2luKHZlX2Rpciwg \
-     J1NjcmlwdHMnKSwgJ2FjdGl2YXRlX3RoaXMucHknKQoKZXhlY2ZpbGUoYWN0aXZhdGVfdGhpcywg \
-     ZGljdChfX2ZpbGVfXz1hY3RpdmF0ZV90aGlzKSkK'.decode('base64')"
+init-hook=
+    import sys, os
+
+    if 'VIRTUAL_ENV' not in os.environ: \
+        sys.exit(0)
+
+    ve_dir = os.environ['VIRTUAL_ENV']
+    ve_dir in sys.path or sys.path.insert(0, ve_dir)
+    activate_this = os.path.join(os.path.join(ve_dir, 'bin'), 'activate_this.py')
+
+    # Fix for windows
+    if not os.path.exists(activate_this): \
+        activate_this = os.path.join(os.path.join(ve_dir, 'Scripts'), 'activate_this.py')
+
+    with open(activate_this) as fp: \
+        exec(fp.read(), dict(__file__=activate_this))
 
 # Use multiple processes to speed up Pylint.
 jobs=1


### PR DESCRIPTION
## Description of new feature, or changes
This PR expands the base64-encoded pylint init hook into its full script (because INI files can do that; idk what [this guy](http://blog.algarvio.me/2012/12/27/pylint-+-virtualenv/) was smoking), and converts its usage of `execfile(path)` to `exec(open(path).read())` to support execution under Python 3.

NOTE: backslashes / continuation operators were used for indented blocks, 'cause though INI files can support multiple lines (though blank lines are removed by default), I had no idea how to also have it respect leading whitespace.


## Checklist

- [X] Your branch is up-to-date with the base branch
- [X] ~You've included at least one test if this is a new feature~
- [X] All tests are passing

## Related Issues and Discussions
Mentioned here: https://github.com/manrajgrover/halo/issues/102#issuecomment-431643972
