### PR TITLE
BUG FIX: fix python 3.6+ compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 backports.shutil_get_terminal_size==1.0.0;python_version < '3.3'
-log_symbols==0.0.11
+log_symbols==0.0.12
 spinners==0.0.23
 cursor==1.2.0
 termcolor==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md") as infile:
 setup(
     name='halo',
     packages=find_packages(exclude=('tests', 'examples')),
-    version='0.0.22',
+    version='0.0.23',
     license='MIT',
     description='Beautiful terminal spinners in Python',
     long_description=long_description,


### PR DESCRIPTION
<!--  Use the following format for your Pull Request title:

    BUG FIX
    {Issue ID|BUG FIX}: {Description of change}

    OTHERS
    {Whatever}: {Description of change} -->

## Description of new feature, or changes
Python 3.6 introduced new package "enum".
Due to an old version of subpackage (https://github.com/manrajgrover/py-log-symbols), old "enum34" is used which is in conflict with python 3.6 ad higher.
Pull request updates the library to the newest version, which fixes the problem

See also: 
https://stackoverflow.com/questions/43124775/why-python-3-6-1-throws-attributeerror-module-enum-has-no-attribute-intflag
and first answer

## Checklist

- [x] Your branch is up-to-date with the base branch
- [ ] You've included at least one test if this is a new feature
- [ ] All tests are passing

Lint test is failing, but it is not relevant with the change

## Related Issues and Discussions

https://github.com/manrajgrover/py-log-symbols/issues/14

## People to notify
@manrajgrover 
