### PR TITLE
BUG FIX: Prevent python3 unicode error when reading long_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 from setuptools import setup, find_packages  # pylint: disable=no-name-in-module,import-error
-
+import io
 
 def dependencies(file):
     with open(file) as f:
         return f.read().splitlines()
 
 
-with open("README.md") as infile:
+with io.open("README.md", 'r', encoding='utf-8') as infile:
     long_description = infile.read()
 
 setup(


### PR DESCRIPTION
The long_description is pulling from README.md, which has a unicode character in it. This sometimes causes Python 3 installations to fail with a UnicodeDecodeError if the locale setting is mismatched with the file encoding (as is the case when installing to a container). The solution is to force the encoding at the time the file is opened.