### PR TITLE
FIXES #81: Add tests to verify ANSI codes are in the spinner output

### DIFF
--- a/tests/test_halo.py
+++ b/tests/test_halo.py
@@ -13,7 +13,6 @@ try:
 except ImportError:
     from io import StringIO
 
-from colorama import Fore
 from spinners.spinners import Spinners
 
 from halo import Halo

--- a/tests/test_halo_notebook.py
+++ b/tests/test_halo_notebook.py
@@ -11,8 +11,7 @@ from spinners.spinners import Spinners
 
 from halo import HaloNotebook
 from halo._utils import get_terminal_columns, is_supported
-from tests._utils import decode_utf_8_text, encode_utf_8_text, strip_ansi
-from tests._utils import strip_ansi, find_colors, encode_utf_8_text, decode_utf_8_text
+from tests._utils import decode_utf_8_text, encode_utf_8_text, find_colors, strip_ansi
 
 from termcolor import COLORS
 
@@ -40,7 +39,7 @@ class TestHaloNotebook(unittest.TestCase):
         """
         pass
 
-    def _get_test_output(self, spinner):
+    def _get_test_output(self, spinner, no_ansi=True):
         """Clean the output from Output widget and return it in list form.
 
         Returns
@@ -53,7 +52,11 @@ class TestHaloNotebook(unittest.TestCase):
         output_colors = []
 
         for line in spinner.output.outputs:
-            clean_line = strip_ansi(line['text'].strip('\r'))
+            if no_ansi:
+                clean_line = strip_ansi(line['text'].strip('\r'))
+            else:
+                clean_line = line['text'].strip('\r')
+
             if clean_line != '':
                 output_text.append(get_coded_text(clean_line))
 
@@ -406,6 +409,20 @@ class TestHaloNotebook(unittest.TestCase):
         self.assertEqual(text, "foo")
         self.assertRegexpMatches(symbol, pattern)
         spinner.stop()
+
+    def test_spinner_color(self):
+        """Test ANSI escape characters are present
+        """
+
+        for color, color_int in COLORS.items():
+            spinner = HaloNotebook(color=color)
+            spinner.start()
+            output = self._get_test_output(spinner, no_ansi=False)
+            spinner.stop()
+
+            output_merged = [arr for c in output['colors'] for arr in c]
+
+            self.assertEquals(str(color_int) in output_merged, True)
 
     def tearDown(self):
         """Clean up things after every test.


### PR DESCRIPTION
## Description of new feature, or changes
As in [my other PR](https://github.com/manrajgrover/halo/pull/101) for halo I've added pretty much the same test for halo notebook. `_get_test_output` has been refactored to take a `no_ansi` arg, which defaults to `True`. We then use this in the new test to keep the ANSI escape characters and compare them to those supplied by colorama.

I also cleared up an un-needed import in the other test file.

Sorry it took me a while to get to!

## Checklist

- [x] Your branch is up-to-date with the base branch
- [x] You've included at least one test if this is a new feature
- [x] All tests are passing

## Related Issues and Discussions
#81 

## People to notify
@manrajgrover 
