### PR TITLE
{Issue #5}: Whitelist windows spinners

### DIFF
--- a/halo/halo.py
+++ b/halo/halo.py
@@ -261,6 +261,8 @@ class Halo(object):
             Contains frames and interval defining spinner
         """
         default_spinner = Spinners['dots'].value
+        windows_spinners = ['balloon', 'balloon2', 'bouncingBar', 'dqpb', 'flip', 'layer', 'line', 'pipe',
+                            'simpleDots', 'simpleDotsScrolling', 'star2', 'shark', 'toggle13']
 
         if spinner and type(spinner) == dict:
             return spinner
@@ -271,7 +273,10 @@ class Halo(object):
             else:
                 return default_spinner
         else:
-            return Spinners['line'].value
+            if all([is_text_type(spinner), spinner in Spinners.__members__, spinner in windows_spinners]):
+                return Spinners[spinner].value
+            else:
+                return Spinners['line'].value
 
     def _get_text(self, text):
         """Creates frames based on the selected animation

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 coverage==4.4.1
 nose==1.3.7
-pylint==1.7.2
+pylint==2.3.0
 tox==2.8.2
 twine==1.12.1

--- a/tests/test_halo.py
+++ b/tests/test_halo.py
@@ -551,6 +551,22 @@ class TestHalo(unittest.TestCase):
 
         self.assertIn('foo', output[0])
 
+    def test_windows_whitelist(self):
+        if is_supported():
+            pass
+        else:
+            instance = Halo()
+            default_spinner_value = "line"
+
+            instance.spinner = default_spinner_value
+            self.assertEqual(default_spinner, instance.spinner)
+
+            instance.spinner = "balloon"
+            self.assertEqual(Spinners['balloon'].value, instance.spinner)
+
+            instance.spinner = "monkey"
+            self.assertEqual(default_spinner, instance.spinner)
+
     def tearDown(self):
         pass
 


### PR DESCRIPTION
## Description of new feature, or changes
Whitelists spinners that are compatible with Windows OS in `halo.py`'s  `_get_spinner()` method instead of always defaulting to `line`. Still defaults to `line` if spinner is not in the whitelist.

## Checklist

- [x] Your branch is up-to-date with the base branch
- [x] You've included at least one test if this is a new feature
- [x] All tests are passing

I don't have much experience with testing, so I have to ask: is it being tested properly? Double-checking the `tox` output for `halo.py`, line 270 is the `is_supported()` check and lines 271-274 are only used in a non-Windows environment.

```
(venv36) C:\Users\User\PycharmProjects\halo>tox -e py36
GLOB sdist-make: C:\Users\User\PycharmProjects\halo\setup.py
py36 create: C:\Users\User\PycharmProjects\halo\.tox\py36
py36 installdeps: -rC:\Users\User\PycharmProjects\halo/requirements.txt, -rC:\Users\User\PycharmProjects\halo/requirements-dev.txt
py36 inst: C:\Users\User\PycharmProjects\halo\.tox\dist\halo-0.0.23.zip
py36 installed: astroid==2.2.5,attrs==19.1.0,bleach==3.1.0,certifi==2019.3.9,chardet==3.0.4,colorama==0.3.9,coverage==4.4.1,cursor==1.2.0,decorator==4.4.0,defusedxml==0.5.0,docu
tils==0.14,entrypoints==0.3,enum34==1.1.6,halo==0.0.23,idna==2.8,ipykernel==5.1.0,ipython==5.7.0,ipython-genutils==0.2.0,ipywidgets==7.1.0,isort==4.3.17,Jinja2==2.10.1,jsonschem
a==3.0.1,jupyter-client==5.2.4,jupyter-core==4.4.0,lazy-object-proxy==1.3.1,log-symbols==0.0.12,MarkupSafe==1.1.1,mccabe==0.6.1,mistune==0.8.4,nbconvert==5.4.1,nbformat==4.4.0,n
ose==1.3.7,notebook==5.7.8,pandocfilters==1.4.2,pickleshare==0.7.5,pkginfo==1.5.0.1,pluggy==0.9.0,prometheus-client==0.6.0,prompt-toolkit==1.0.15,py==1.8.0,Pygments==2.3.1,pylin
t==2.3.0,pyrsistent==0.14.11,python-dateutil==2.8.0,pywinpty==0.5.5,pyzmq==18.0.1,readme-renderer==24.0,requests==2.21.0,requests-toolbelt==0.9.1,Send2Trash==1.5.0,simplegeneric
==0.8.1,six==1.12.0,spinners==0.0.23,termcolor==1.1.0,terminado==0.8.2,testpath==0.4.2,tornado==6.0.2,tox==2.8.2,tqdm==4.31.1,traitlets==4.3.2,twine==1.12.1,typed-ast==1.3.1,url
lib3==1.24.1,virtualenv==16.4.3,wcwidth==0.1.7,webencodings==0.5.1,widgetsnbextension==3.1.4,wrapt==1.11.1
py36 runtests: PYTHONHASHSEED='929'
py36 runtests: commands[0] | nosetests --cover-package=halo --with-coverage --cover-erase --cover-branches --nologcapture
.......................................................
Name                    Stmts   Miss Branch BrPart  Cover   Missing
-------------------------------------------------------------------
halo\__init__.py            6      0      0      0   100%
halo\_utils.py             51     14     10      4    70%   9-10, 30, 45-46, 52, 54, 58-59, 131-134, 150, 29->30, 51->52, 53->54, 149->150
halo\halo.py              200     15     54      7    91%   82, 85-88, 271-274, 349-350, 406, 427, 456, 534, 546-547, 84->85, 270->271, 405->406, 426->427, 447->451, 455->456, 5
33->534
halo\halo_notebook.py      59      3     14      3    92%   58, 87, 99, 57->58, 86->87, 98->99
-------------------------------------------------------------------
TOTAL                     316     32     78     14    88%
----------------------------------------------------------------------
Ran 55 tests in 45.855s

OK
___________________________________________________________________________________ summary ____________________________________________________________________________________
  py36: commands succeeded
  congratulations :)

(venv36) C:\Users\User\PycharmProjects\halo>tox -e lint
GLOB sdist-make: C:\Users\User\PycharmProjects\halo\setup.py
lint recreate: C:\Users\User\PycharmProjects\halo\.tox\lint
lint installdeps: -rC:\Users\User\PycharmProjects\halo/requirements.txt, -rC:\Users\User\PycharmProjects\halo/requirements-dev.txt
lint inst: C:\Users\User\PycharmProjects\halo\.tox\dist\halo-0.0.23.zip
lint installed: astroid==2.2.5,attrs==19.1.0,bleach==3.1.0,certifi==2019.3.9,chardet==3.0.4,colorama==0.3.9,coverage==4.4.1,cursor==1.2.0,decorator==4.4.0,defusedxml==0.5.0,docu
tils==0.14,entrypoints==0.3,enum34==1.1.6,halo==0.0.23,idna==2.8,ipykernel==5.1.0,ipython==5.7.0,ipython-genutils==0.2.0,ipywidgets==7.1.0,isort==4.3.17,Jinja2==2.10.1,jsonschem
a==3.0.1,jupyter-client==5.2.4,jupyter-core==4.4.0,lazy-object-proxy==1.3.1,log-symbols==0.0.12,MarkupSafe==1.1.1,mccabe==0.6.1,mistune==0.8.4,nbconvert==5.4.1,nbformat==4.4.0,n
ose==1.3.7,notebook==5.7.8,pandocfilters==1.4.2,pickleshare==0.7.5,pkginfo==1.5.0.1,pluggy==0.9.0,prometheus-client==0.6.0,prompt-toolkit==1.0.15,py==1.8.0,Pygments==2.3.1,pylin
t==2.3.0,pyrsistent==0.14.11,python-dateutil==2.8.0,pywinpty==0.5.5,pyzmq==18.0.1,readme-renderer==24.0,requests==2.21.0,requests-toolbelt==0.9.1,Send2Trash==1.5.0,simplegeneric
==0.8.1,six==1.12.0,spinners==0.0.23,termcolor==1.1.0,terminado==0.8.2,testpath==0.4.2,tornado==6.0.2,tox==2.8.2,tqdm==4.31.1,traitlets==4.3.2,twine==1.12.1,typed-ast==1.3.1,url
lib3==1.24.1,virtualenv==16.4.3,wcwidth==0.1.7,webencodings==0.5.1,widgetsnbextension==3.1.4,wrapt==1.11.1
lint runtests: PYTHONHASHSEED='496'
lint runtests: commands[0] | pylint --errors-only --rcfile=C:\Users\User\PycharmProjects\halo/.pylintrc --output-format=colorized halo
___________________________________________________________________________________ summary ____________________________________________________________________________________
  lint: commands succeeded
  congratulations :)


```

## Related Issues and Discussions
Partially fixes #5 except for

> Now let's say we document Windows supported spinners.

This could be part of #6, which I can address using Sphinx in another PR.

It also doesn't address

> I wish to support Python 2.7 for as long as possible and yes, there are dependents who make use of this version.

I don't know what Python 2.7.x will have issues with, but I can try it out.

## People to notify
@manrajgrover 
