### PR TITLE
{Issue #6}: Add sphinx docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,19 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line.
+SPHINXOPTS    =
+SPHINXBUILD   = sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+
+:end
+popd

--- a/docs/source/about/faqs.rst
+++ b/docs/source/about/faqs.rst
@@ -1,0 +1,17 @@
+FAQs
+====
+
+Anticipated :abbr:`FAQs (Frequently Asked Questions)`.
+
+What spinners are compatible with Windows Operating System?
+-----------------------------------------------------------
+
+Compatible spinners are defined in :meth:`~halo.halo.Halo._get_spinner()` from :mod:`halo.halo`:
+
+.. literalinclude:: ../../../halo/halo.py
+    :linenos:
+    :lineno-start: 251
+    :language: python
+    :lines: 251-274
+
+Currently, it defaults to ``line``.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,77 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# http://www.sphinx-doc.org/en/master/config
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+import recommonmark
+from recommonmark.transform import AutoStructify
+
+sys.path.insert(0, os.path.abspath('../..'))
+
+# -- Project information -----------------------------------------------------
+
+project = 'halo'
+copyright = '2019, Manraj Singh'
+author = 'Manraj Singh'
+
+# The full version, including alpha/beta/rc tags
+release = '0.0.23'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.intersphinx',
+    'recommonmark',
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+# Handle mapping of external module documentation written with Sphinx
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3/', None),
+}
+
+autodoc_default_flags = ['members', 'undoc-members', 'private-members',
+                         'special-members', 'inherited-members', 'show-inheritance']
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+
+# -- Extension configuration -------------------------------------------------
+
+def setup(app):
+    app.add_config_value('recommonmark_config', {
+            'auto_toc_tree_section': 'Contents',
+            'enable_eval_rst': True,
+            }, True)
+    app.add_transform(AutoStructify)

--- a/docs/source/halo.rst
+++ b/docs/source/halo.rst
@@ -1,0 +1,30 @@
+halo package
+============
+
+Submodules
+----------
+
+halo.halo module
+----------------
+
+.. automodule:: halo.halo
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+halo.halo\_notebook module
+--------------------------
+
+.. automodule:: halo.halo_notebook
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: halo
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,107 @@
+.. halo documentation master file, created by
+   sphinx-quickstart on Mon Apr 15 04:18:11 2019.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+.. image:: ../../art/halo.png
+   :height: 50px
+   :align: center
+
+halo
+====
+
+Beautiful spinners for terminal, IPython and Jupyter
+
+.. image:: ../../art/doge_spin.svg
+
+Install
+-------
+
+.. code-block:: bash
+
+   pip install halo
+
+
+Usage
+-----
+
+.. code-block:: python
+
+   from halo import Halo
+
+   spinner = Halo(text='Loading', spinner='dots')
+   spinner.start()
+
+   # Run time consuming work here
+   # You can also change properties for spinner as and when you want
+
+   spinner.stop()
+
+Alternatively, you can use halo with Python's ``with`` statement:
+
+.. code-block:: python
+
+   from halo import Halo
+
+   with Halo(text='Loading', spinner='dots'):
+	   # Run time consuming work here
+
+
+Finally, you can use halo as a decorator:
+
+.. code-block:: python
+
+   from halo import Halo
+
+   @Halo(text='Loading', spinner='dots')
+   def long_running_function():
+	   # Run time consuming work here
+	   pass
+
+   long_running_function()
+
+How to contribute?
+------------------
+
+Please see `Contributing guidelines`_ for more information.
+
+.. _Contributing guidelines: https://github.com/manrajgrover/halo/blob/master/.github/CONTRIBUTING.md
+
+Like it?
+--------
+
+🌟 this repo to show support. Let me know you liked it on `Twitter`_.
+Also, share the `project`_.
+
+.. _Twitter: https://twitter.com/manrajsgrover
+.. _project: https://twitter.com/intent/tweet?url=https%3A%2F%2Fgithub.com%2Fmanrajgrover%2Fhalo&via=manrajsgrover&text=Checkout%20%23halo%20-%20a%20beautiful%20%23terminal%20%23spinners%20library%20for%20%23python&hashtags=github%2C%20pypi
+
+Related
+-------
+
+* `py-spinners`_ - Spinners in Python
+* `py-log-symbols`_ - Log Symbols in Python
+* `ora`_ - Elegant terminal spinners in JavaScript (inspiration behind this project)
+
+.. _py-spinners: https://github.com/manrajgrover/py-spinners
+.. _py-log-symbols: https://github.com/manrajgrover/py-log-symbols
+.. _ora: https://github.com/sindresorhus/ora
+
+License
+-------
+
+`MIT`_ © Manraj Singh
+
+.. _MIT: https://github.com/manrajgrover/halo/blob/master/LICENSE
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API Reference
+
+   modules
+
+.. toctree::
+   :maxdepth: 2
+   :caption: About
+
+   about/faqs

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,0 +1,7 @@
+halo
+====
+
+.. toctree::
+   :maxdepth: 4
+
+   halo

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,4 @@
+sphinx==2.0.1
+Jinja2==2.10.1
+sphinx-rtd-theme==0.4.3
+recommonmark==0.5.0


### PR DESCRIPTION
## Description of new feature, or changes
Initializes documentation using Sphinx. Supports both reStructuredText and markdown. Content is mainly from docstrings via autodoc and a rewrite of README.md to reStructuredText format. Also added FAQ page that includes mention of Windows compatible spinners. Specifically, that it defaults to `line` for now. Compatibility with other operating systems can be added as needed.

## Checklist

- [x] Your branch is up-to-date with the base branch
- [ ] You've included at least one test if this is a new feature
- [x] All tests are passing

Documentation is that fuzzy area that is difficult to write tests for. Please advise if tests are needed and how best to do them.

## Related Issues and Discussions
Fixes #6 and finishes off #5.

Proofing may be needed to ensure all the desired information is present. For example, in `docs/source/conf.py` I set `copyright = '2019, Manraj Singh'` rather than `copyright = '2019, Manraj Singh and contributors'`.

There are also tons of warnings with the docstrings that I'd like to fix (mainly spacing).

## People to notify
@manrajgrover 
