### PR TITLE
Improvement: Don't fix the dependency versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ matrix:
     env: TOXENV=py27
   - python: '2.7'
     env: TOXENV=lint
-  - python: '3.4'
-    env: TOXENV=py34
   - python: '3.5'
     env: TOXENV=py35
   - python: '3.6'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,13 +14,7 @@ environment:
       PYTHON_HOME: C:\Python27
       PYTHON_VERSION: '2.7'
       PYTHON_ARCH: '32'
-    
-    - TOXENV: 'py34'
-      TOXPYTHON: C:\Python34\python.exe
-      PYTHON_HOME: C:\Python34
-      PYTHON_VERSION: '3.4'
-      PYTHON_ARCH: '32'
-    
+
     - TOXENV: 'py35'
       TOXPYTHON: C:\Python35\python.exe
       PYTHON_HOME: C:\Python35

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-coverage==4.4.1
-nose==1.3.7
-pylint==1.7.2
-tox==2.8.2
-twine==1.12.1
+coverage>=4.4.1
+nose>=1.3.7
+pylint>=1.7.2
+tox>=2.8.2
+twine>=1.12.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-backports.shutil_get_terminal_size==1.0.0;python_version < '3.3'
-log_symbols==0.0.13
-spinners==0.0.23
-cursor==1.2.0
-termcolor==1.1.0
-colorama==0.3.9
-six==1.12.0
+log_symbols>=0.0.13
+spinners>=0.0.23
+cursor>=1.2.0
+termcolor>=1.1.0
+colorama>=0.3.9
+six>=1.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+backports.shutil_get_terminal_size>=1.0.0;python_version < '3.3'
 log_symbols>=0.0.13
 spinners>=0.0.23
 cursor>=1.2.0

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with io.open("README.md", encoding='utf-8') as infile:
 setup(
     name='halo',
     packages=find_packages(exclude=('tests', 'examples')),
-    version='0.0.26',
+    version='0.0.27',
     license='MIT',
     description='Beautiful terminal spinners in Python',
     long_description=long_description,


### PR DESCRIPTION
## Description of new feature, or changes

This PR changes the versions of all requirements to greater or equal the existing version number. It currently is very easy to break halo just by installing a newer package version and pkg_config will complain. This unnecessarily restricts the number of environments in which halo can be used.

I don't think there is any reason not to do this and one can probably assume that most packages will be backwards compatible.

If you'd be okay with it I'd propose to get rid of the `requirements.txt` (and its dev version) and instead just put them in `setup.py` directly. I can offer to implement this. There is a short discussion about the merits of each approach here:

https://pip.readthedocs.io/en/1.1/requirements.html