### PR TITLE
Use _write in stop_and_persist

### DIFF
--- a/halo/halo.py
+++ b/halo/halo.py
@@ -580,8 +580,8 @@ class Halo(object):
         ][0])
 
         try:
-            self._stream.write(output)
+            self._write(output)
         except UnicodeEncodeError:
-            self._stream.write(encode_utf_8_text(output))
+            self._write(encode_utf_8_text(output))
 
         return self

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with io.open("README.md", encoding='utf-8') as infile:
 setup(
     name='halo',
     packages=find_packages(exclude=('tests', 'examples')),
-    version='0.0.27',
+    version='0.0.28',
     license='MIT',
     description='Beautiful terminal spinners in Python',
     long_description=long_description,

--- a/tests/test_halo.py
+++ b/tests/test_halo.py
@@ -453,6 +453,23 @@ class TestHalo(unittest.TestCase):
         except ValueError as e:
             self.fail('Attempted to write to a closed stream: {}'.format(e))
 
+    def test_closing_stream_before_persistent(self):
+        """Test no I/O is performed on streams closed before stop_and_persist is called
+        """
+        stream = io.StringIO()
+        spinner = Halo(text='foo', stream=stream)
+        spinner.start()
+        time.sleep(0.5)
+
+        # no exception raised after closing the stream means test was successful
+        try:
+            stream.close()
+
+            time.sleep(0.5)
+            spinner.stop_and_persist('done')
+        except ValueError as e:
+            self.fail('Attempted to write to a closed stream: {}'.format(e))
+
     def test_setting_enabled_property(self):
         """Test if spinner stops writing when enabled property set to False
         """


### PR DESCRIPTION
<!--  Use the following format for your Pull Request title:

    BUG FIX
    {Issue ID|BUG FIX}: {Description of change}

    OTHERS
    {Whatever}: {Description of change} -->

## Description of new feature, or changes
<!-- What exactly does this PR do? -->
I noticed that the method `Halo._write` is used everywhere, except in `Halo._stop_and_persist`, where the string is written directly to the _stream.

In pytest the output is captured and the stream gets closed after the test, so this fix was critical for me.

## Checklist

- [x] Your branch is up-to-date with the base branch
- [x] You've included at least one test if this is a new feature
- [x] All tests are passing

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #12" -->

## People to notify
<!-- Please @mention relevant people here: -->
