### PR TITLE
{Issue #47} Synchronous spinner

### DIFF
--- a/halo/halo.py
+++ b/halo/halo.py
@@ -397,7 +397,7 @@ class Halo(object):
         -------
         self
         """
-        while not self._stop_spinner.is_set() and not self.manual_step:
+        while not self._stop_spinner.is_set():
             self._render_frame()
             time.sleep(0.001 * self._interval)
 
@@ -409,8 +409,7 @@ class Halo(object):
         -------
         self
         """
-        if not self._stop_spinner.is_set():
-            self._render_frame()
+        self._render_frame()
         
         return self
 
@@ -480,13 +479,14 @@ class Halo(object):
             return self
 
         self._hide_cursor()
-
-        self._stop_spinner = threading.Event()
-        self._spinner_thread = threading.Thread(target=self.render)
-        self._spinner_thread.setDaemon(True)
-        self._render_frame()
-        self._spinner_id = self._spinner_thread.name
-        self._spinner_thread.start()
+        
+        if not self.manual_step:
+            self._stop_spinner = threading.Event()
+            self._spinner_thread = threading.Thread(target=self.render)
+            self._spinner_thread.setDaemon(True)
+            self._render_frame()
+            self._spinner_id = self._spinner_thread.name
+            self._spinner_thread.start()
 
         return self
 

--- a/halo/halo.py
+++ b/halo/halo.py
@@ -13,7 +13,7 @@ import time
 import cursor
 from log_symbols.symbols import LogSymbols
 from spinners.spinners import Spinners
-
+sys.path += [r"E:\User Files\Documents\Repos\halo\halo"]
 from halo._utils import (colored_frame, decode_utf_8_text, get_environment,
                          get_terminal_columns, is_supported, is_text_type,
                          encode_utf_8_text)
@@ -31,7 +31,8 @@ class Halo(object):
     SPINNER_PLACEMENTS = ('left', 'right',)
 
     def __init__(self, text='', color='cyan', text_color=None, spinner=None,
-                 animation=None, placement='left', interval=-1, enabled=True, stream=sys.stdout):
+                 animation=None, placement='left', interval=-1, enabled=True,
+                 manual_step=False, stream=sys.stdout):
         """Constructs the Halo object.
         Parameters
         ----------
@@ -59,6 +60,7 @@ class Halo(object):
         """
         self._color = color
         self._animation = animation
+        self.manual_step = manual_step
 
         self.spinner = spinner
         self.text = text
@@ -74,7 +76,7 @@ class Halo(object):
         self._stop_spinner = None
         self._spinner_id = None
         self.enabled = enabled
-
+        
         environment = get_environment()
 
         def clean_up():
@@ -395,10 +397,21 @@ class Halo(object):
         -------
         self
         """
-        while not self._stop_spinner.is_set():
+        while not self._stop_spinner.is_set() and not self.manual_step:
             self._render_frame()
             time.sleep(0.001 * self._interval)
 
+        return self
+    
+    def step(self):
+        """Runs the render once.
+        Returns
+        -------
+        self
+        """
+        if not self._stop_spinner.is_set():
+            self._render_frame()
+        
         return self
 
     def frame(self):

--- a/halo/halo.py
+++ b/halo/halo.py
@@ -13,7 +13,7 @@ import time
 import cursor
 from log_symbols.symbols import LogSymbols
 from spinners.spinners import Spinners
-sys.path += [r"E:\User Files\Documents\Repos\halo\halo"]
+
 from halo._utils import (colored_frame, decode_utf_8_text, get_environment,
                          get_terminal_columns, is_supported, is_text_type,
                          encode_utf_8_text)
@@ -76,7 +76,7 @@ class Halo(object):
         self._stop_spinner = None
         self._spinner_id = None
         self.enabled = enabled
-        
+
         environment = get_environment()
 
         def clean_up():

--- a/halo/halo_notebook.py
+++ b/halo/halo_notebook.py
@@ -10,15 +10,18 @@ from halo._utils import (colored_frame, decode_utf_8_text)
 
 
 class HaloNotebook(Halo):
-    def __init__(self, text='', color='cyan', text_color=None, spinner=None, placement='left',
-                 animation=None, interval=-1, enabled=True, stream=sys.stdout):
+    def __init__(self, text='', color='cyan', text_color=None, spinner=None,
+                 placement='left', animation=None, interval=-1, enabled=True,
+                 manual_step=False, stream=sys.stdout):
         super(HaloNotebook, self).__init__(text=text,
                                            color=color,
                                            text_color=text_color,
                                            spinner=spinner,
                                            placement=placement,
                                            animation=animation,
-                                           interval=interval, enabled=enabled,
+                                           interval=interval,
+                                           enabled=enabled,
+                                           manual_step=manual_step,
                                            stream=stream)
         self.output = self._make_output_widget()
 
@@ -62,9 +65,12 @@ class HaloNotebook(Halo):
 
         display(self.output)
         self._stop_spinner = threading.Event()
+        self._run_spinner = threading.Event()
         self._spinner_thread = threading.Thread(target=self.render)
         self._spinner_thread.setDaemon(True)
-        self._render_frame()
+        if not self.manual_step:
+            self._render_frame()
+            self._run_spinner.set()
         self._spinner_id = self._spinner_thread.name
         self._spinner_thread.start()
 

--- a/tests/test_halo.py
+++ b/tests/test_halo.py
@@ -627,12 +627,25 @@ class TestHalo(unittest.TestCase):
         """
         default_spinner = Halo()
         self.assertEqual(default_spinner.manual_step, False)
-        
-        manual_spinner = Halo(manual_step=True)
-        self.assertEqual(manual_spinner.manual_step, True)
-        manual_spinner.step()
-        self.assertEqual(manual_spinner._frame_index, 1)
-        
+
+
+        manual_spinner = Halo(spinner='dots', manual_step=True,
+                              stream=self._stream)
+
+        texts = ['foo', 'bar', 'baz']
+
+        manual_spinner.start()
+        for text in texts:
+            manual_spinner.text=text
+            manual_spinner.step()
+            time.sleep(1)
+        manual_spinner.stop()
+        output = self._get_test_output()['text']
+
+        self.assertEqual(output[0], '{} {}'.format(frames[0], texts[0]))
+        self.assertEqual(output[1], '{} {}'.format(frames[1], texts[1]))
+        self.assertEqual(output[2], '{} {}'.format(frames[2], texts[2]))
+
     def tearDown(self):
         pass
 

--- a/tests/test_halo.py
+++ b/tests/test_halo.py
@@ -621,7 +621,18 @@ class TestHalo(unittest.TestCase):
             self._stream = out
 
         self.assertIn('foo', output[0])
-
+    
+    def test_manual_step(self):
+        """Test manual step
+        """
+        default_spinner = Halo()
+        self.assertEqual(default_spinner.manual_step, False)
+        
+        manual_spinner = Halo(manual_step=True)
+        self.assertEqual(manual_spinner.manual_step, True)
+        manual_spinner.step()
+        self.assertEqual(manual_spinner._frame_index, 1)
+        
     def tearDown(self):
         pass
 


### PR DESCRIPTION
## Description of new feature, or changes
Added the ability to manually render single spinner steps, via:
 - 'manual_step' argument when creating Halo class instance
- '.step()' method to trigger single frame to render
- 'test_manual_step' test

## Usage
```
with Halo(spinner='dots', manual_step=True) as spinner:
    for text in ["foo","bar"]*5:
        spinner.text = 'Loading {}'.format(text)
        spinner.step()
        do_something(text)
```
or
```
spinner = Halo(spinner="dots", manual_step=True)
spinner.start()
for text in ["foo", "bar"]*5:
    spinner.text=text
    spinner.step()
    do_something(text)
spinner.stop()
```

## Checklist
- [x] Your branch is up-to-date with the base branch
- [x] You've included at least one test if this is a new feature
- [x] All tests are passing

## Related Issues and Discussions
Fixes #47 (new feature)

## People to notify
@steelman
