### PR TITLE
BUG FIX ISSUE #59 : stop_and_persist function works as it should

### DIFF
--- a/halo/halo_notebook.py
+++ b/halo/halo_notebook.py
@@ -38,7 +38,7 @@ class HaloNotebook(Halo):
             self.output.outputs += self._output('\r')
             self.output.outputs += self._output(self.CLEAR_LINE)
 
-        self.output.outputs = self._output()
+        self.output.outputs += self._output()
         return self
 
     def _render_frame(self):


### PR DESCRIPTION
#123  Description of new feature, or changes
Issue #59 Output gets hidden on stop_and_persist in Jupyter notebooks - added output to self.output.outputs instead of reassignment to persist output when cell finishes running.

## Checklist

- [x] Your branch is up-to-date with the base branch
- [x] You've included at least one test if this is a new feature
- [x] All tests are passing

## Related Issues and Discussions 
Fixes #59 

