### PR TITLE
Inject spinner instance as parameter to decorated function

### DIFF
--- a/halo/halo.py
+++ b/halo/halo.py
@@ -106,8 +106,17 @@ class Halo(object):
 
         @functools.wraps(f)
         def wrapped(*args, **kwargs):
-            with self:
-                return f(*args, **kwargs)
+            with self as spinner:
+                try:
+                    # Inject the spinner as a function parameter.
+                    # The injected parameter is merged with the original arguments
+                    wrapped_kwargs = dict(spinner=spinner)
+                    wrapped_kwargs.update(kwargs)
+                    return f(*args, **wrapped_kwargs)
+                except TypeError:
+                    # This happens when the wrapped function does not declare the optional parameter
+                    # In this case we do not inject the parameter
+                    return f(*args, **kwargs)
 
         return wrapped
 


### PR DESCRIPTION
I propose to inject the spinner instance as an optional parameter to functions decorated by halo. This was my use case:
```
@Halo(text='Doing work', spinner='dots', color="red")
def initialize_git(spinner=None):
    try:
        my_complicated_function()
    except Exception:
        spinner.fail("Failed!")
        raise
    spinner.succeed("Succeeded!")
```

## Description
This PR adds functionality to declare the optional keyword argument as a parameter to obtain a reference to the spinner object. This does not break anything and is completely optional.

## Checklist
- [x ] Your branch is up-to-date with the base branch
- [x ] You've included at least one test if this is a new feature
- [x ] All tests are passing

## Further considerations
It is also possible to inject the spinner instance as a positional argument, but this could not be made optional.