### PR TITLE
add windows terminal support

### DIFF
--- a/halo/_utils.py
+++ b/halo/_utils.py
@@ -3,6 +3,7 @@
 """
 import codecs
 import platform
+import os
 import six
 try:
     from shutil import get_terminal_size
@@ -26,10 +27,10 @@ def is_supported():
 
     os_arch = platform.system()
 
-    if os_arch != 'Windows':
+    if os_arch != 'Windows' or os.environ.get('WT_SESSION') is not None:
         return True
 
-    return False
+    return True
 
 
 def get_environment():


### PR DESCRIPTION
<!--  Use the following format for your Pull Request title:

    BUG FIX
    {Issue ID|BUG FIX}: {Description of change}

    OTHERS
    {Whatever}: {Description of change} -->

## Description of new feature, or changes
<!-- What exactly does this PR do? -->
Adds support for all spinners when using windows terminal.

Note: If using jupyter notebook spawned from windows terminal, when all characters display correctly. If using jupyter notebook not spawned from WT, then the characters display fallbacks dispite not needing them. HaloNotebook could just patch the ```is_supported``` call``` to ignore it, but that would not work as well for LogSymbols.

## Checklist

- [x] Your branch is up-to-date with the base branch
- [x] You've included at least one test if this is a new feature (bug fix)
- [ ] All tests are passing

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #12" -->
Fixes #5
## People to notify
<!-- Please @mention relevant people here: -->
