### PR TITLE
fixed overwrite of spinner value with default spinner in Jupyter Notebooks running on Windows

### DIFF
--- a/halo/halo_notebook.py
+++ b/halo/halo_notebook.py
@@ -6,8 +6,8 @@ import threading
 import halo.cursor as cursor
 
 from halo import Halo
-from halo._utils import colored_frame, decode_utf_8_text
-
+from halo._utils import colored_frame, decode_utf_8_text, is_text_type
+from spinners.spinners import Spinners
 
 class HaloNotebook(Halo):
     def __init__(
@@ -120,3 +120,25 @@ class HaloNotebook(Halo):
 
         with self.output:
             self.output.outputs = self._output(output)
+
+    def _get_spinner(self, spinner):
+        """Extracts spinner value from options and returns value
+        containing spinner frames and interval, defaults to 'dots' spinner.
+        Parameters
+        ----------
+        spinner : dict, str
+            Contains spinner value or type of spinner to be used
+        Returns
+        -------
+        dict
+            Contains frames and interval defining spinner
+        """
+        default_spinner = Spinners['dots'].value
+
+        if spinner and type(spinner) == dict:
+            return spinner
+
+        if all([is_text_type(spinner), spinner in Spinners.__members__]):
+            return Spinners[spinner].value
+        else:
+            return default_spinner


### PR DESCRIPTION
<!--  Use the following format for your Pull Request title:

    BUG FIX
    {Issue ID|BUG FIX}: {Description of change}

    OTHERS
    {Whatever}: {Description of change} -->

## Description of new feature, or changes
<!-- What exactly does this PR do? -->
Removed check of OS causing spinner value to be overwritten with default value in Jupyter Notebook on Windows.  If you went to the trouble to use HaloNotebook, you are almost certainly using a browser-based notebook capable of rendering the spinner

Resolves #141 
## Checklist

- [ ] Your branch is up-to-date with the base branch
- [ ] You've included at least one test if this is a new feature
- [ ] All tests are passing

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #12" -->

## People to notify
<!-- Please @mention relevant people here: -->
