### PR TITLE
#151: Remove colorama init, Only use colorama on windows

### DIFF
--- a/halo/_utils.py
+++ b/halo/_utils.py
@@ -4,15 +4,25 @@
 import codecs
 import platform
 import six
+import sys
 try:
     from shutil import get_terminal_size
 except ImportError:
     from backports.shutil_get_terminal_size import get_terminal_size
 
-from colorama import init
 from termcolor import colored
 
-init(autoreset=True)
+
+wrap_stream_for_win = None
+
+if sys.platform.startswith("win"):
+    try:
+        import colorama
+    except ImportError:
+        pass
+    else:
+        def wrap_stream_for_win(stream):  # pylint: disable=function-redefined
+            return colorama.AnsiToWin32(stream, autoreset=True).stream
 
 
 def is_supported():

--- a/halo/halo.py
+++ b/halo/halo.py
@@ -23,6 +23,7 @@ from halo._utils import (
     is_supported,
     is_text_type,
     encode_utf_8_text,
+    wrap_stream_for_win,
 )
 
 
@@ -87,6 +88,8 @@ class Halo(object):
         self._interval = (
             int(interval) if int(interval) > 0 else self._spinner["interval"]
         )
+        if wrap_stream_for_win:
+            stream = wrap_stream_for_win(stream)
         self._stream = stream
 
         self.placement = placement

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ backports.shutil_get_terminal_size>=1.0.0;python_version < '3.3'
 log_symbols>=0.0.14
 spinners>=0.0.24
 termcolor>=1.1.0
-colorama>=0.3.9
+colorama>=0.3.9; sys_platform == "win32"
 six>=1.12.0


### PR DESCRIPTION
<!--  Use the following format for your Pull Request title:

    BUG FIX
    {Issue ID|BUG FIX}: {Description of change}

    OTHERS
    {Whatever}: {Description of change} -->

## Description of new feature, or changes
<!-- What exactly does this PR do? -->
Colorama.init escapes all ansi codes by default on stdout / stderr when not in a tty, regardless of OS, which breaks color output. Instead of globally affecting stdout and stderr at library import time, only wrap the stream that Halo uses. 

Also, I turned colorama into a conditional dependency, seeing as its only needed on windows.

## Checklist

- [x] Your branch is up-to-date with the base branch
- [ ] You've included at least one test if this is a new feature
- [x] All tests are passing

## Related Issues and Discussions
https://github.com/manrajgrover/halo/issues/151

## People to notify
<!-- Please @mention relevant people here: -->
