### PR TITLE
Added ability to indent spinners

### DIFF
--- a/examples/indent_spin.py
+++ b/examples/indent_spin.py
@@ -1,0 +1,7 @@
+from halo import Halo
+from time import sleep
+
+with Halo(text="Look at that bullet!", indent=" • ") as s:
+    sleep(1)
+    s.succeed()
+

--- a/halo/halo.py
+++ b/halo/halo.py
@@ -51,6 +51,7 @@ class Halo(object):
         interval=-1,
         enabled=True,
         stream=sys.stdout,
+        indent="",
     ):
         """Constructs the Halo object.
         Parameters
@@ -96,6 +97,7 @@ class Halo(object):
         self._stop_spinner = None
         self._spinner_id = None
         self.enabled = enabled
+        self.indent = indent
 
         environment = get_environment()
 
@@ -439,7 +441,8 @@ class Halo(object):
         self._frame_index = self._frame_index % len(frames)
 
         text_frame = self.text_frame()
-        return "{0} {1}".format(
+        return "{0}{1} {2}".format(
+            self.indent,
             *[
                 (text_frame, frame)
                 if self._placement == "right"
@@ -597,7 +600,8 @@ class Halo(object):
 
         self.stop()
 
-        output = "{0} {1}\n".format(
+        output = "{0}{1} {2}\n".format(
+            self.indent,
             *[(text, symbol) if self._placement == "right" else (symbol, text)][0]
         )
 

--- a/tests/test_halo.py
+++ b/tests/test_halo.py
@@ -622,6 +622,17 @@ class TestHalo(unittest.TestCase):
 
         self.assertIn('foo', output[0])
 
+    def test_indent(self):
+        """Test indents spinner
+        """
+        indent = "  "
+        spinner = Halo(text="spam", spinner="dots", indent=indent, stream=self._stream)
+        spinner.start()
+        spinner.stop()
+        output = self._get_test_output()["text"]
+        print(f"\t\tDEBUG: {output}")
+        self.assertEqual(indent, output[0][:len(indent)])
+
     def tearDown(self):
         pass
 


### PR DESCRIPTION
#146: Added ability to indent spinners

## Description of new feature, or changes
Halo has a new argument, indent, which takes a string and appends it to the front of the displayed text, acting like an indent. For example, `Halo(text="foo", spinner="dots", indent=" * ")` would append " * " to the front of the spinner without the indent. Also, this is my first PR. Please tell me if I'm doing anything wrong

## Checklist

- [x] Your branch is up-to-date with the base branch
- [x] You've included at least one test if this is a new feature
- [x] All tests are passing

## Related Issues and Discussions
Fixes #146 
