### PR TITLE
BUG FIX: Fix colors in jupyter by only using colorama on windows

### DIFF
--- a/halo/_utils.py
+++ b/halo/_utils.py
@@ -4,15 +4,22 @@
 import codecs
 import platform
 import six
+import sys
+
 try:
     from shutil import get_terminal_size
 except ImportError:
     from backports.shutil_get_terminal_size import get_terminal_size
 
-from colorama import init
 from termcolor import colored
 
-init(autoreset=True)
+
+IS_WIN = any(sys.platform.startswith(i) for i in ['win32', 'cygwin'])
+
+if IS_WIN:
+    import colorama
+    colorama.init(autoreset=True)
+
 
 
 def is_supported():


### PR DESCRIPTION
## Description of new feature, or changes
Initializing `colorama` wraps stdout and stderr, and causes color-printing to no longer work in jupyter.  Since `colorama` is only necessary on Windows, this PR makes it so we don't initialize it except on Windows.  

<img width="336" alt="image" src="https://user-images.githubusercontent.com/30874603/140328225-04b2d9a5-ccb5-464f-82ce-b0494d3974c9.png">


## Checklist
- [x] Your branch is up-to-date with the base branch
- [x] You've included at least one test if this is a new feature
- [x] All tests are passing

## Related Issues and Discussions
Here's a related PR on tqdm: https://github.com/tqdm/tqdm/issues/178
