### PR TITLE
feat: @halo wrapped function can accept halo instance as 'spinner' parameter

### DIFF
--- a/halo/halo.py
+++ b/halo/halo.py
@@ -128,8 +128,16 @@ class Halo(object):
 
         @functools.wraps(f)
         def wrapped(*args, **kwargs):
-            with self:
-                return f(*args, **kwargs)
+            try:
+                if 'spinner' in f.__code__.co_varnames[:f.__code__.co_argcount]:
+                    with self as h:
+                        return f(spinner=h, *args, **kwargs)
+                else:
+                    with self:
+                        return f(*args, **kwargs)
+            except ValueError:
+                with self:
+                    return f(*args, **kwargs)
 
         return wrapped
 


### PR DESCRIPTION
## Description of new feature, or changes

When wrapping a function with `@Halo` syntax the wrapped function has no access to the spinner and therefore cannot do any of the extra stuff with the spinner, such as change the text. With this change, if the wrapped function accepts a `spinner` parameter, the halo instance is passed as the value for that parameter.

## Checklist

- [x] Your branch is up-to-date with the base branch
- [ ] You've included at least one test if this is a new feature
- [ ] All tests are passing

## Related Issues and Discussions

n/a

## People to notify

n/a
