### PR TITLE
Add ability to force use of a custom spinner in Windows

### DIFF
--- a/halo/halo.py
+++ b/halo/halo.py
@@ -51,6 +51,7 @@ class Halo(object):
         interval=-1,
         enabled=True,
         stream=sys.stdout,
+        force=False
     ):
         """Constructs the Halo object.
         Parameters
@@ -88,7 +89,7 @@ class Halo(object):
             int(interval) if int(interval) > 0 else self._spinner["interval"]
         )
         self._stream = stream
-
+        self.force = force
         self.placement = placement
         self._frame_index = 0
         self._text_index = 0
@@ -333,7 +334,7 @@ class Halo(object):
         if spinner and type(spinner) == dict:
             return spinner
 
-        if is_supported():
+        if is_supported() or self.force:
             if all([is_text_type(spinner), spinner in Spinners.__members__]):
                 return Spinners[spinner].value
             else:

--- a/halo/halo.py
+++ b/halo/halo.py
@@ -80,6 +80,7 @@ class Halo(object):
         force : bool, optional
             Should force the use of the custom spinner if the platform is not supported
         """
+        self.force = force
         self._color = color
         self._animation = animation
 
@@ -91,7 +92,6 @@ class Halo(object):
             int(interval) if int(interval) > 0 else self._spinner["interval"]
         )
         self._stream = stream
-        self.force = force
         self.placement = placement
         self._frame_index = 0
         self._text_index = 0

--- a/halo/halo.py
+++ b/halo/halo.py
@@ -77,6 +77,8 @@ class Halo(object):
             Spinner enabled or not.
         stream : io, optional
             Output.
+        force : bool, optional
+            Should force the use of the custom spinner if the platform is not supported
         """
         self._color = color
         self._animation = animation


### PR DESCRIPTION
## Description of new feature, or changes
This PR adds he ability to force the use on the custom defined spinner on windows by passing `force=True` to the class initialization

## Checklist
Done

- [x] Your branch is up-to-date with the base branch
- [x] You've included at least one test if this is a new feature
- [x] All tests are passing

## Related Issues and Discussions
None

## People to notify
None
